### PR TITLE
Remove Minimal Supported Rust Version from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.31.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Remove 1.31.0 Rust version since we're using dependencies that work only
on current stable and later versions.