### PR TITLE
Add get_nodegroup function and update visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,15 @@ impl Client {
     ) -> Result<Vec<nodegroup::schemas::Nodegroup>, Error> {
         nodegroup::api::list_nodegroups(self, cluster_id)
     }
+
+    /// Get a cluster nodegroup.
+    pub fn get_nodegroup(
+        &self,
+        cluster_id: &str,
+        nodegroup_id: &str,
+    ) -> Result<nodegroup::schemas::Nodegroup, Error> {
+        nodegroup::api::get_nodegroup(self, cluster_id, nodegroup_id)
+    }
 }
 
 /// Builder for `Client`.

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -21,3 +21,21 @@ pub fn list_nodegroups(
 
     Ok(deserialized.nodegroups)
 }
+
+pub fn get_nodegroup(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+) -> Result<schemas::Nodegroup, Error> {
+    let path = format!(
+        "/{}/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
+    );
+    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let body = client.do_request(req)?;
+
+    let deserialized: schemas::NodegroupRoot =
+        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+
+    Ok(deserialized.nodegroup)
+}

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -8,40 +8,46 @@ use super::super::node::schemas::Node;
 #[derive(Debug, Deserialize)]
 pub struct Nodegroup {
     // Nodegroup identifier.
-    id: String,
+    pub id: String,
 
     // Timestamp in UTC timezone of when the nodegroup has been created.
-    created_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
 
     // Timestamp in UTC timezone of when the nodegroup has been updated.
-    updated_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
 
     // Cluster identifier.
-    cluster_id: String,
+    pub cluster_id: String,
 
     // OpenStack flavor identifier for all nodes in the nodegroup.
-    flavor_id: String,
+    pub flavor_id: String,
 
     // Initial volume size in GB for each node.
-    volume_gb: u32,
+    pub volume_gb: u32,
 
     // Initial blockstorage volume type for each node.
-    volume_type: String,
+    pub volume_type: String,
 
     // Flag that represents if nodes use local volume.
-    local_volume: bool,
+    pub local_volume: bool,
 
     // OpenStack availability zone for all nodes in the nodegroup.
-    availability_zone: String,
+    pub availability_zone: String,
 
     // All nodes in the nodegroup.
-    nodes: Vec<Node>,
+    pub nodes: Vec<Node>,
 
     // A map of user-defined Kubernetes labels for each node in the group.
-    labels: HashMap<String, String>,
+    pub labels: HashMap<String, String>,
 }
 
-/// NodegroupsRoot represents a list of deserialized nodegroups.
+/// NodegroupRoot represents a root of a deserialized nodegroup.
+#[derive(Debug, Deserialize)]
+pub struct NodegroupRoot {
+    pub nodegroup: Nodegroup,
+}
+
+/// NodegroupsRoot represents a root of a list with deserialized nodegroups.
 #[derive(Debug, Deserialize)]
 pub struct NodegroupsRoot {
     pub nodegroups: Vec<Nodegroup>,

--- a/tests/nodegroup_get.rs
+++ b/tests/nodegroup_get.rs
@@ -1,0 +1,37 @@
+mod common;
+
+use std::env;
+
+const TEST_CLUSTER_ID: &str = "MKS_TEST_CLUSTER_ID";
+const TEST_NODEGROUP_ID: &str = "MKS_TEST_NODEGROUP_ID";
+
+#[test]
+fn get_nodegroup() {
+    if !common::integration_tests_are_enabled() {
+        return;
+    }
+
+    let cluster_id = env::var(TEST_CLUSTER_ID).expect(
+        format!(
+            "Failed to read {} environment variable to test get_nodegroup method",
+            TEST_CLUSTER_ID
+        )
+        .as_str(),
+    );
+
+    let nodegroup_id = env::var(TEST_NODEGROUP_ID).expect(
+        format!(
+            "Failed to read {} environment variable to test get_nodegroup method",
+            TEST_NODEGROUP_ID
+        )
+        .as_str(),
+    );
+
+    let client = common::setup();
+    let nodegroup = client
+        .get_nodegroup(cluster_id.as_str(), nodegroup_id.as_str())
+        .expect("Failed to get a nodegroup");
+
+    assert_eq!(nodegroup.id, nodegroup_id);
+    println!("Nodegroup: {:?}", nodegroup);
+}


### PR DESCRIPTION
Add get_nodegroup function and method for the Client struct.

Make all fields of Nodegroup struct public.

Add get_nodegroup integration test.

For #8 