### PR TITLE
Implement delete_nodegroup method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,11 @@ impl Client {
     ) -> Result<(), Error> {
         nodegroup::api::create_nodegroup(self, cluster_id, opts)
     }
+
+    /// Delete a cluster nodegroup.
+    pub fn delete_nodegroup(&self, cluster_id: &str, nodegroup_id: &str) -> Result<(), Error> {
+        nodegroup::api::delete_nodegroup(self, cluster_id, nodegroup_id)
+    }
 }
 
 /// Builder for `Client`.

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -58,3 +58,18 @@ pub fn create_nodegroup(
 
     Ok(())
 }
+
+pub fn delete_nodegroup(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+) -> Result<(), Error> {
+    let path = format!(
+        "/{}/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
+    );
+    let req = client.new_request(Method::DELETE, path.as_str(), None)?;
+    client.do_request(req)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add a method to delete a cluster nodegroup.

Integration test will be implemented later.

For #8 