### PR TITLE
Implement resize_nodegroup method for the Client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,16 @@ impl Client {
     pub fn delete_nodegroup(&self, cluster_id: &str, nodegroup_id: &str) -> Result<(), Error> {
         nodegroup::api::delete_nodegroup(self, cluster_id, nodegroup_id)
     }
+
+    /// Resize a cluster nodegroup.
+    pub fn resize_nodegroup(
+        &self,
+        cluster_id: &str,
+        nodegroup_id: &str,
+        opts: &nodegroup::schemas::NodegroupResizeOpts,
+    ) -> Result<(), Error> {
+        nodegroup::api::resize_nodegroup(self, cluster_id, nodegroup_id, opts)
+    }
 }
 
 /// Builder for `Client`.

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -73,3 +73,21 @@ pub fn delete_nodegroup(
 
     Ok(())
 }
+
+pub fn resize_nodegroup(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+    opts: &schemas::NodegroupResizeOpts,
+) -> Result<(), Error> {
+    let serialized = serde_json::to_string(&opts).map_err(Error::SerializeError)?;
+
+    let path = format!(
+        "/{}/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
+    );
+    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    client.do_request(req)?;
+
+    Ok(())
+}

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -146,3 +146,16 @@ impl NodegroupCreateOpts {
 pub struct NodegroupCreateOptsRoot<'a> {
     pub nodegroup: &'a NodegroupCreateOpts,
 }
+
+/// NodegroupResizeOpts represents a nodegroup resize options for the API resize request.
+#[derive(Debug, Serialize)]
+pub struct NodegroupResizeOpts {
+    desired: u32,
+}
+
+impl NodegroupResizeOpts {
+    // Initialize a new NodegroupResizeOpts.
+    pub fn new(desired: u32) -> NodegroupResizeOpts {
+        NodegroupResizeOpts { desired }
+    }
+}


### PR DESCRIPTION
Implement a method to resize a cluster nodegroup.

Integration test will be implemented later.

For #8 