### PR TITLE
Implement update_nodegroup method for the Client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,16 @@ impl Client {
     ) -> Result<(), Error> {
         nodegroup::api::resize_nodegroup(self, cluster_id, nodegroup_id, opts)
     }
+
+    /// Update a cluster nodegroup.
+    pub fn update_nodegroup(
+        &self,
+        cluster_id: &str,
+        nodegroup_id: &str,
+        opts: &nodegroup::schemas::NodegroupUpdateOpts,
+    ) -> Result<(), Error> {
+        nodegroup::api::update_nodegroup(self, cluster_id, nodegroup_id, opts)
+    }
 }
 
 /// Builder for `Client`.

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -4,7 +4,7 @@ use super::super::error::Error;
 use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS};
 use super::super::Client;
 use super::schemas;
-use crate::nodegroup::schemas::NodegroupCreateOptsRoot;
+use crate::nodegroup::schemas::{NodegroupCreateOptsRoot, NodegroupUpdateOptsRoot};
 
 pub fn list_nodegroups(
     client: &Client,
@@ -81,6 +81,25 @@ pub fn resize_nodegroup(
     opts: &schemas::NodegroupResizeOpts,
 ) -> Result<(), Error> {
     let serialized = serde_json::to_string(&opts).map_err(Error::SerializeError)?;
+
+    let path = format!(
+        "/{}/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
+    );
+    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    client.do_request(req)?;
+
+    Ok(())
+}
+
+pub fn update_nodegroup(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+    opts: &schemas::NodegroupUpdateOpts,
+) -> Result<(), Error> {
+    let root_opts = NodegroupUpdateOptsRoot { nodegroup: opts };
+    let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
     let path = format!(
         "/{}/{}/{}/{}/{}",

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -159,3 +159,34 @@ impl NodegroupResizeOpts {
         NodegroupResizeOpts { desired }
     }
 }
+
+/// NodegroupUpdateOpts represents a nodegroup update options for the API update request.
+#[derive(Debug, Serialize)]
+pub struct NodegroupUpdateOpts {
+    labels: Option<HashMap<String, String>>,
+}
+
+impl NodegroupUpdateOpts {
+    // Initialize a new NodegroupUpdateOpts.
+    pub fn new() -> NodegroupUpdateOpts {
+        NodegroupUpdateOpts { labels: None }
+    }
+
+    // Update user-defined Kubernetes labels for each node in the group.
+    pub fn with_labels(mut self, labels: HashMap<String, String>) -> NodegroupUpdateOpts {
+        self.labels = Some(labels);
+        self
+    }
+}
+
+impl Default for NodegroupUpdateOpts {
+    fn default() -> Self {
+        NodegroupUpdateOpts::new()
+    }
+}
+
+/// NodegroupUpdateOptsRoot represents a root of a nodegroup update options.
+#[derive(Debug, Serialize)]
+pub struct NodegroupUpdateOptsRoot<'a> {
+    pub nodegroup: &'a NodegroupUpdateOpts,
+}


### PR DESCRIPTION
Implement a method to update a cluster nodegroup.

Integration test will be implemented later.

For #8