### PR TITLE
Implement get_cluster method for the Client

### DIFF
--- a/src/cluster/api.rs
+++ b/src/cluster/api.rs
@@ -1,0 +1,17 @@
+use hyper::Method;
+
+use super::super::error::Error;
+use super::super::resource_url::{API_VERSION, CLUSTERS};
+use super::super::Client;
+use super::schemas;
+
+pub fn get_cluster(client: &Client, cluster_id: &str) -> Result<schemas::Cluster, Error> {
+    let path = format!("/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id);
+    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let body = client.do_request(req)?;
+
+    let deserialized: schemas::ClusterRoot =
+        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+
+    Ok(deserialized.cluster)
+}

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod api;
+pub mod schemas;

--- a/src/cluster/schemas.rs
+++ b/src/cluster/schemas.rs
@@ -1,0 +1,106 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/// Status represents a enum with various cluster statuses.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Status {
+    Active,
+    PendingCreate,
+    PendingUpdate,
+    PendingUpgrade,
+    PendingRotateCerts,
+    PendingDelete,
+    PendingResize,
+    PendingNodeReinstall,
+    PendingUpgradePatchVersion,
+    PendingUpgradeMinorVersion,
+    PendingUpdateNodegroup,
+    PendingUpgradeMastersConfiguration,
+    PendingUpgradeClusterConfiguration,
+    Maintenance,
+    Error,
+    Unknown,
+}
+
+/// Cluster represents a deserialized cluster body from an API response.
+#[derive(Deserialize, Debug)]
+pub struct Cluster {
+    /// Cluster identifier.
+    pub id: String,
+
+    /// Timestamp in UTC timezone of when the cluster has been created.
+    pub created_at: DateTime<Utc>,
+
+    /// Timestamp in UTC timezone of when the cluster has been updated.
+    pub updated_at: Option<DateTime<Utc>>,
+
+    /// Cluster name.
+    pub name: String,
+
+    /// Cluster status.
+    pub status: Status,
+
+    /// Project reference.
+    pub project_id: String,
+
+    /// Network reference
+    pub network_id: String,
+
+    /// Subnet reference.
+    pub subnet_id: String,
+
+    /// IP of the Kubernetes API.
+    pub kube_api_ip: String,
+
+    /// Current Kubernetes version of the cluster.
+    pub kube_version: String,
+
+    /// Region of where the cluster is located.
+    pub region: String,
+
+    /// Timestamp in UTC timezone of when the PKI-tree of the cluster has been updated.
+    pub pki_tree_updated_at: Option<DateTime<Utc>>,
+
+    /// UTC time in "hh:mm:ss" format of when the cluster will start its
+    /// maintenance tasks.
+    pub maintenance_window_start: String,
+
+    /// UTC time in "hh:mm:ss" format of when the cluster will end its
+    /// maintenance tasks.
+    pub maintenance_window_end: String,
+
+    /// Timestamp in UTC timezone of the last cluster maintenance start.
+    pub maintenance_last_start: DateTime<Utc>,
+
+    /// Flag that indicates if worker nodes are allowed to be reinstalled automatically
+    /// in case of their unavailability or unhealthiness.
+    pub enable_autorepair: bool,
+
+    /// Flag that indicates if Kubernetes patch version of the cluster is allowed to be upgraded
+    /// automatically.
+    pub enable_patch_version_auto_upgrade: bool,
+
+    /// Flag that indicates that cluster has only a single master and that
+    /// control-plane is not in highly available mode.
+    pub zonal: bool,
+
+    /// Additional Kubernetes-related options
+    /// such as pod security policy, feature gates, etc.
+    pub kubernetes_options: KubernetesOptions,
+}
+
+/// ClusterRoot represents a root of a deserialized cluster.
+#[derive(Debug, Deserialize)]
+pub struct ClusterRoot {
+    pub cluster: Cluster,
+}
+
+/// KubernetesOptions represents additional Kubernetes-related options
+/// such as pod security policy, feature gates, etc.
+#[derive(Debug, Deserialize)]
+pub struct KubernetesOptions {
+    /// Flag that indicates if PodSecurityPolicy admission controller
+    /// must be turned on or off.
+    pub enable_pod_security_policy: bool,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ type HttpsConnector = hyper_tls::HttpsConnector<hyper::client::HttpConnector>;
 pub mod error;
 pub mod resource_url;
 
+pub mod cluster;
 pub mod kubeversion;
 pub mod node;
 pub mod nodegroup;
@@ -225,6 +226,14 @@ impl Client {
         opts: &nodegroup::schemas::NodegroupUpdateOpts,
     ) -> Result<(), Error> {
         nodegroup::api::update_nodegroup(self, cluster_id, nodegroup_id, opts)
+    }
+}
+
+/// Methods to work with clusters.
+impl Client {
+    /// Get a cluster.
+    pub fn get_cluster(&self, cluster_id: &str) -> Result<cluster::schemas::Cluster, Error> {
+        cluster::api::get_cluster(self, cluster_id)
     }
 }
 

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -1,0 +1,26 @@
+use std::env;
+
+pub mod common;
+
+#[test]
+fn get_cluster() {
+    if !common::integration_tests_are_enabled() {
+        return;
+    }
+
+    let cluster_id = env::var(common::TEST_CLUSTER_ID).expect(
+        format!(
+            "Failed to read {} environment variable to test get_cluster method",
+            common::TEST_CLUSTER_ID
+        )
+        .as_str(),
+    );
+
+    let client = common::setup();
+    let cluster = client
+        .get_cluster(cluster_id.as_str())
+        .expect("Failed to get a cluster");
+
+    assert_eq!(cluster.id, cluster_id);
+    println!("Cluster: {:?}\n", cluster);
+}


### PR DESCRIPTION
Implement a method to get a cluster.

Add Status enum, Cluster, ClusterRoot and KubernetesOptions structs.

Add an integration test.

For #7