### PR TITLE
Refactor nodegroup struct names and docs

### DIFF
--- a/src/cluster/schemas.rs
+++ b/src/cluster/schemas.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::super::nodegroup::schemas::NodegroupCreateOpts;
+use super::super::nodegroup;
 
 /// Status represents a enum with various cluster statuses.
 #[derive(Deserialize, Debug)]
@@ -121,7 +121,7 @@ pub struct CreateOpts {
     subnet_id: Option<String>,
     kube_version: String,
     region: String,
-    nodegroups: Option<Vec<NodegroupCreateOpts>>,
+    nodegroups: Option<Vec<nodegroup::schemas::CreateOpts>>,
     maintenance_window_start: Option<String>,
     enable_autorepair: Option<bool>,
     enable_patch_version_auto_upgrade: Option<bool>,
@@ -159,7 +159,10 @@ impl CreateOpts {
     }
 
     /// Add nodegroups parameters.
-    pub fn with_nodegroups(mut self, nodegroups: Vec<NodegroupCreateOpts>) -> CreateOpts {
+    pub fn with_nodegroups(
+        mut self,
+        nodegroups: Vec<nodegroup::schemas::CreateOpts>,
+    ) -> CreateOpts {
         self.nodegroups = Some(nodegroups);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,14 +177,6 @@ impl Client {
 
 /// Methods to work with nodegroups.
 impl Client {
-    /// List cluster nodegroups.
-    pub fn list_nodegroups(
-        &self,
-        cluster_id: &str,
-    ) -> Result<Vec<nodegroup::schemas::Nodegroup>, Error> {
-        nodegroup::api::list_nodegroups(self, cluster_id)
-    }
-
     /// Get a cluster nodegroup.
     pub fn get_nodegroup(
         &self,
@@ -194,11 +186,19 @@ impl Client {
         nodegroup::api::get_nodegroup(self, cluster_id, nodegroup_id)
     }
 
+    /// List cluster nodegroups.
+    pub fn list_nodegroups(
+        &self,
+        cluster_id: &str,
+    ) -> Result<Vec<nodegroup::schemas::Nodegroup>, Error> {
+        nodegroup::api::list_nodegroups(self, cluster_id)
+    }
+
     /// Create a cluster nodegroup.
     pub fn create_nodegroup(
         &self,
         cluster_id: &str,
-        opts: &nodegroup::schemas::NodegroupCreateOpts,
+        opts: &nodegroup::schemas::CreateOpts,
     ) -> Result<(), Error> {
         nodegroup::api::create_nodegroup(self, cluster_id, opts)
     }
@@ -213,7 +213,7 @@ impl Client {
         &self,
         cluster_id: &str,
         nodegroup_id: &str,
-        opts: &nodegroup::schemas::NodegroupResizeOpts,
+        opts: &nodegroup::schemas::ResizeOpts,
     ) -> Result<(), Error> {
         nodegroup::api::resize_nodegroup(self, cluster_id, nodegroup_id, opts)
     }
@@ -223,7 +223,7 @@ impl Client {
         &self,
         cluster_id: &str,
         nodegroup_id: &str,
-        opts: &nodegroup::schemas::NodegroupUpdateOpts,
+        opts: &nodegroup::schemas::UpdateOpts,
     ) -> Result<(), Error> {
         nodegroup::api::update_nodegroup(self, cluster_id, nodegroup_id, opts)
     }

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -4,24 +4,6 @@ use super::super::error::Error;
 use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS};
 use super::super::Client;
 use super::schemas;
-use crate::nodegroup::schemas::{NodegroupCreateOptsRoot, NodegroupUpdateOptsRoot};
-
-pub fn list_nodegroups(
-    client: &Client,
-    cluster_id: &str,
-) -> Result<Vec<schemas::Nodegroup>, Error> {
-    let path = format!(
-        "/{}/{}/{}/{}",
-        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS
-    );
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
-    let body = client.do_request(req)?;
-
-    let deserialized: schemas::NodegroupsRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
-
-    Ok(deserialized.nodegroups)
-}
 
 pub fn get_nodegroup(
     client: &Client,
@@ -41,12 +23,29 @@ pub fn get_nodegroup(
     Ok(deserialized.nodegroup)
 }
 
+pub fn list_nodegroups(
+    client: &Client,
+    cluster_id: &str,
+) -> Result<Vec<schemas::Nodegroup>, Error> {
+    let path = format!(
+        "/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS
+    );
+    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let body = client.do_request(req)?;
+
+    let deserialized: schemas::ListRoot =
+        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+
+    Ok(deserialized.nodegroups)
+}
+
 pub fn create_nodegroup(
     client: &Client,
     cluster_id: &str,
-    opts: &schemas::NodegroupCreateOpts,
+    opts: &schemas::CreateOpts,
 ) -> Result<(), Error> {
-    let root_opts = NodegroupCreateOptsRoot { nodegroup: opts };
+    let root_opts = schemas::CreateOptsRoot { nodegroup: opts };
     let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
     let path = format!(
@@ -78,7 +77,7 @@ pub fn resize_nodegroup(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,
-    opts: &schemas::NodegroupResizeOpts,
+    opts: &schemas::ResizeOpts,
 ) -> Result<(), Error> {
     let serialized = serde_json::to_string(&opts).map_err(Error::SerializeError)?;
 
@@ -96,9 +95,9 @@ pub fn update_nodegroup(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,
-    opts: &schemas::NodegroupUpdateOpts,
+    opts: &schemas::UpdateOpts,
 ) -> Result<(), Error> {
-    let root_opts = NodegroupUpdateOptsRoot { nodegroup: opts };
+    let root_opts = schemas::UpdateOptsRoot { nodegroup: opts };
     let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
     let path = format!(

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -7,37 +7,37 @@ use super::super::node::schemas::Node;
 /// Nodegroup represents a deserialized nodegroup body from an API response.
 #[derive(Debug, Deserialize)]
 pub struct Nodegroup {
-    // Nodegroup identifier.
+    /// Nodegroup identifier.
     pub id: String,
 
-    // Timestamp in UTC timezone of when the nodegroup has been created.
+    /// Timestamp in UTC timezone of when the nodegroup has been created.
     pub created_at: DateTime<Utc>,
 
-    // Timestamp in UTC timezone of when the nodegroup has been updated.
+    /// Timestamp in UTC timezone of when the nodegroup has been updated.
     pub updated_at: Option<DateTime<Utc>>,
 
-    // Cluster identifier.
+    /// Cluster identifier.
     pub cluster_id: String,
 
-    // OpenStack flavor identifier for all nodes in the nodegroup.
+    /// OpenStack flavor identifier for all nodes in the nodegroup.
     pub flavor_id: String,
 
-    // Initial volume size in GB for each node.
+    /// Initial volume size in GB for each node.
     pub volume_gb: u32,
 
-    // Initial blockstorage volume type for each node.
+    /// Initial blockstorage volume type for each node.
     pub volume_type: String,
 
-    // Flag that represents if nodes use local volume.
+    /// Flag that represents if nodes use local volume.
     pub local_volume: bool,
 
-    // OpenStack availability zone for all nodes in the nodegroup.
+    /// OpenStack availability zone for all nodes in the nodegroup.
     pub availability_zone: String,
 
-    // All nodes in the nodegroup.
+    /// All nodes in the nodegroup.
     pub nodes: Vec<Node>,
 
-    // A map of user-defined Kubernetes labels for each node in the group.
+    /// A map of user-defined Kubernetes labels for each node in the group.
     pub labels: HashMap<String, String>,
 }
 
@@ -47,15 +47,15 @@ pub struct NodegroupRoot {
     pub nodegroup: Nodegroup,
 }
 
-/// NodegroupsRoot represents a root of a list with deserialized nodegroups.
+/// ListRoot represents a root of a list with deserialized nodegroups.
 #[derive(Debug, Deserialize)]
-pub struct NodegroupsRoot {
+pub struct ListRoot {
     pub nodegroups: Vec<Nodegroup>,
 }
 
-/// NodegroupCreateOpts represents a nodegroup create options for the API create request.
+/// Create options for a new nodegroup.
 #[derive(Debug, Serialize)]
-pub struct NodegroupCreateOpts {
+pub struct CreateOpts {
     count: u32,
     flavor_id: Option<String>,
     cpus: Option<u32>,
@@ -69,10 +69,9 @@ pub struct NodegroupCreateOpts {
     labels: Option<HashMap<String, String>>,
 }
 
-impl NodegroupCreateOpts {
-    // Initialize a new NodegroupCreateOpts.
-    pub fn new(count: u32, local_volume: bool, availability_zone: String) -> NodegroupCreateOpts {
-        NodegroupCreateOpts {
+impl CreateOpts {
+    pub fn new(count: u32, local_volume: bool, availability_zone: String) -> CreateOpts {
+        CreateOpts {
             count,
             flavor_id: None,
             cpus: None,
@@ -87,106 +86,104 @@ impl NodegroupCreateOpts {
         }
     }
 
-    // Add a reference to a pre-created flavor.
-    // It can be omitted in most cases.
-    pub fn with_flavor_id(mut self, flavor_id: String) -> NodegroupCreateOpts {
+    /// Add a reference to a pre-created flavor.
+    /// It can be omitted in most cases.
+    pub fn with_flavor_id(mut self, flavor_id: String) -> CreateOpts {
         self.flavor_id = Some(flavor_id);
         self
     }
 
-    // Add a CPU count for each node.
-    // It can be omitted only in cases when flavor_id is set.
-    pub fn with_cpus(mut self, cpus: u32) -> NodegroupCreateOpts {
+    /// Add a CPU count for each node.
+    /// It can be omitted only in cases when flavor_id is set.
+    pub fn with_cpus(mut self, cpus: u32) -> CreateOpts {
         self.cpus = Some(cpus);
         self
     }
 
-    // Add a RAM count in MB for each node.
-    // It can be omitted only in cases when flavor_id is set.
-    pub fn with_ram_mb(mut self, ram_mb: u32) -> NodegroupCreateOpts {
+    /// Add a RAM count in MB for each node.
+    /// It can be omitted only in cases when flavor_id is set.
+    pub fn with_ram_mb(mut self, ram_mb: u32) -> CreateOpts {
         self.ram_mb = Some(ram_mb);
         self
     }
 
-    // Add a volume size in GB for each node.
-    // It can be omitted only in cases when flavor_id is set and volume is local.
-    pub fn with_volume_gb(mut self, volume_gb: u32) -> NodegroupCreateOpts {
+    /// Add a volume size in GB for each node.
+    /// It can be omitted only in cases when flavor_id is set and volume is local.
+    pub fn with_volume_gb(mut self, volume_gb: u32) -> CreateOpts {
         self.volume_gb = Some(volume_gb);
         self
     }
 
-    // Add a blockstorage volume type for each node.
-    // It can be omitted only in cases when flavor_id is set and volume is local.
-    pub fn with_volume_type(mut self, volume_type: String) -> NodegroupCreateOpts {
+    /// Add a blockstorage volume type for each node.
+    /// It can be omitted only in cases when flavor_id is set and volume is local.
+    pub fn with_volume_type(mut self, volume_type: String) -> CreateOpts {
         self.volume_type = Some(volume_type);
         self
     }
 
-    // Add a name of the SSH key that will be added to all nodes.
-    pub fn with_keypair_name(mut self, keypair_name: String) -> NodegroupCreateOpts {
+    /// Add a name of the SSH key that will be added to all nodes.
+    pub fn with_keypair_name(mut self, keypair_name: String) -> CreateOpts {
         self.keypair_name = Some(keypair_name);
         self
     }
 
-    // Add an optional parameter to tune nodes affinity.
-    pub fn with_affinity_policy(mut self, affinity_policy: String) -> NodegroupCreateOpts {
+    /// Add an optional parameter to tune nodes affinity.
+    pub fn with_affinity_policy(mut self, affinity_policy: String) -> CreateOpts {
         self.affinity_policy = Some(affinity_policy);
         self
     }
 
-    // Add a map of user-defined Kubernetes labels for each node in the group.
-    pub fn with_labels(mut self, labels: HashMap<String, String>) -> NodegroupCreateOpts {
+    /// Add a map of user-defined Kubernetes labels for each node in the group.
+    pub fn with_labels(mut self, labels: HashMap<String, String>) -> CreateOpts {
         self.labels = Some(labels);
         self
     }
 }
 
-/// NodegroupCreateOptsRoot represents a root of a nodegroup create options.
+/// CreateOptsRoot represents a root of nodegroup create options.
 #[derive(Debug, Serialize)]
-pub struct NodegroupCreateOptsRoot<'a> {
-    pub nodegroup: &'a NodegroupCreateOpts,
+pub struct CreateOptsRoot<'a> {
+    pub nodegroup: &'a CreateOpts,
 }
 
-/// NodegroupResizeOpts represents a nodegroup resize options for the API resize request.
+/// Options for the nodegroup resize operation.
 #[derive(Debug, Serialize)]
-pub struct NodegroupResizeOpts {
+pub struct ResizeOpts {
     desired: u32,
 }
 
-impl NodegroupResizeOpts {
-    // Initialize a new NodegroupResizeOpts.
-    pub fn new(desired: u32) -> NodegroupResizeOpts {
-        NodegroupResizeOpts { desired }
+impl ResizeOpts {
+    pub fn new(desired: u32) -> ResizeOpts {
+        ResizeOpts { desired }
     }
 }
 
-/// NodegroupUpdateOpts represents a nodegroup update options for the API update request.
+/// Options for the nodegroup update operation.
 #[derive(Debug, Serialize)]
-pub struct NodegroupUpdateOpts {
+pub struct UpdateOpts {
     labels: Option<HashMap<String, String>>,
 }
 
-impl NodegroupUpdateOpts {
-    // Initialize a new NodegroupUpdateOpts.
-    pub fn new() -> NodegroupUpdateOpts {
-        NodegroupUpdateOpts { labels: None }
+impl UpdateOpts {
+    pub fn new() -> UpdateOpts {
+        UpdateOpts { labels: None }
     }
 
-    // Update user-defined Kubernetes labels for each node in the group.
-    pub fn with_labels(mut self, labels: HashMap<String, String>) -> NodegroupUpdateOpts {
+    /// Update user-defined Kubernetes labels for each node in the group.
+    pub fn with_labels(mut self, labels: HashMap<String, String>) -> UpdateOpts {
         self.labels = Some(labels);
         self
     }
 }
 
-impl Default for NodegroupUpdateOpts {
+impl Default for UpdateOpts {
     fn default() -> Self {
-        NodegroupUpdateOpts::new()
+        UpdateOpts::new()
     }
 }
 
-/// NodegroupUpdateOptsRoot represents a root of a nodegroup update options.
+/// UpdateOptsRoot represents a root of nodegroup update options.
 #[derive(Debug, Serialize)]
-pub struct NodegroupUpdateOptsRoot<'a> {
-    pub nodegroup: &'a NodegroupUpdateOpts,
+pub struct UpdateOptsRoot<'a> {
+    pub nodegroup: &'a UpdateOpts,
 }

--- a/tests/nodegroup.rs
+++ b/tests/nodegroup.rs
@@ -1,4 +1,4 @@
-use selectel_mks::nodegroup::schemas::NodegroupCreateOpts;
+use selectel_mks::nodegroup::schemas::CreateOpts;
 use std::env;
 
 pub mod common;
@@ -78,7 +78,7 @@ fn create_nodegroup() {
         .as_str(),
     );
 
-    let opts = NodegroupCreateOpts::new(2, false, az.clone())
+    let opts = CreateOpts::new(2, false, az.clone())
         .with_cpus(1)
         .with_ram_mb(1024)
         .with_volume_gb(10)


### PR DESCRIPTION
Use simpler names like in cluster module.

Use docs comments.

For #19 #8 