### PR TITLE
Nest nodegroup ResizeOpts into "nodegroup" body

### DIFF
--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -79,7 +79,8 @@ pub fn resize_nodegroup(
     nodegroup_id: &str,
     opts: &schemas::ResizeOpts,
 ) -> Result<(), Error> {
-    let serialized = serde_json::to_string(&opts).map_err(Error::SerializeError)?;
+    let root_opts = schemas::ResizeOptsRoot { nodegroup: opts };
+    let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
     let path = format!(
         "/{}/{}/{}/{}/{}/{}",

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -158,6 +158,12 @@ impl ResizeOpts {
     }
 }
 
+/// ResizeOptsRoot represents a root of nodegroup resize options.
+#[derive(Debug, Serialize)]
+pub struct ResizeOptsRoot<'a> {
+    pub nodegroup: &'a ResizeOpts,
+}
+
 /// Options for the nodegroup update operation.
 #[derive(Debug, Serialize)]
 pub struct UpdateOpts {


### PR DESCRIPTION
Add nodegroup ResizeOptsRoot struct to use it in resize_nodegroup
function.

For #8 