### PR TITLE
Use PUT method in nodegroup_update function

### DIFF
--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -105,7 +105,7 @@ pub fn update_nodegroup(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
     );
-    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    let req = client.new_request(Method::PUT, path.as_str(), Some(serialized))?;
     client.do_request(req)?;
 
     Ok(())


### PR DESCRIPTION
Use PUT instead of POST for the nodegroup update call.

For #8 