### PR TITLE
Use &str instead of String in functions signatures

### DIFF
--- a/src/cluster/api.rs
+++ b/src/cluster/api.rs
@@ -7,22 +7,22 @@ use super::schemas;
 
 pub fn get_cluster(client: &Client, cluster_id: &str) -> Result<schemas::Cluster, Error> {
     let path = format!("/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id);
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::ClusterRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.cluster)
 }
 
 pub fn list_clusters(client: &Client) -> Result<Vec<schemas::Cluster>, Error> {
     let path = format!("/{}/{}", API_VERSION, CLUSTERS);
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::ListRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.clusters)
 }
@@ -35,18 +35,18 @@ pub fn create_cluster(
     let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
     let path = format!("/{}/{}", API_VERSION, CLUSTERS);
-    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    let req = client.new_request(Method::POST, &path, Some(serialized))?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::ClusterRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.cluster)
 }
 
 pub fn delete_cluster(client: &Client, cluster_id: &str) -> Result<(), Error> {
     let path = format!("/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id);
-    let req = client.new_request(Method::DELETE, path.as_str(), None)?;
+    let req = client.new_request(Method::DELETE, &path, None)?;
     client.do_request(req)?;
 
     Ok(())

--- a/src/cluster/schemas.rs
+++ b/src/cluster/schemas.rs
@@ -157,13 +157,13 @@ pub struct CreateOpts {
 }
 
 impl CreateOpts {
-    pub fn new(name: String, kube_version: String, region: String) -> CreateOpts {
+    pub fn new(name: &str, kube_version: &str, region: &str) -> CreateOpts {
         CreateOpts {
-            name,
+            name: String::from(name),
             network_id: None,
             subnet_id: None,
-            kube_version,
-            region,
+            kube_version: String::from(kube_version),
+            region: String::from(region),
             nodegroups: None,
             maintenance_window_start: None,
             enable_autorepair: None,
@@ -174,14 +174,14 @@ impl CreateOpts {
     }
 
     /// Add a reference to a pre-created network.
-    pub fn with_network_id(mut self, network_id: String) -> CreateOpts {
-        self.network_id = Some(network_id);
+    pub fn with_network_id(mut self, network_id: &str) -> CreateOpts {
+        self.network_id = Some(String::from(network_id));
         self
     }
 
     /// Add a reference to a pre-created subnet.
-    pub fn with_subnet_id(mut self, subnet_id: String) -> CreateOpts {
-        self.subnet_id = Some(subnet_id);
+    pub fn with_subnet_id(mut self, subnet_id: &str) -> CreateOpts {
+        self.subnet_id = Some(String::from(subnet_id));
         self
     }
 
@@ -196,8 +196,8 @@ impl CreateOpts {
 
     /// Add maintenance_window_start in UTC.
     /// It should be in hh:mm:ss format.
-    pub fn with_maintenance_window_start(mut self, maintenance_window_start: String) -> CreateOpts {
-        self.maintenance_window_start = Some(maintenance_window_start);
+    pub fn with_maintenance_window_start(mut self, maintenance_window_start: &str) -> CreateOpts {
+        self.maintenance_window_start = Some(String::from(maintenance_window_start));
         self
     }
 

--- a/src/kubeversion/api.rs
+++ b/src/kubeversion/api.rs
@@ -7,11 +7,11 @@ use super::schemas;
 
 pub fn list_kube_versions(client: &Client) -> Result<Vec<schemas::KubeVersion>, Error> {
     let path = format!("/{}/{}", API_VERSION, KUBEVERSIONS);
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::KubeVersionsRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.kube_versions)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,13 +102,13 @@ impl Client {
         // Add user-agent header.
         req.headers_mut().insert(
             USER_AGENT,
-            HeaderValue::from_str(self.user_agent.as_str()).map_err(|_| Error::RequestError)?,
+            HeaderValue::from_str(&self.user_agent).map_err(|_| Error::RequestError)?,
         );
 
         // Add x-auth-token header.
         req.headers_mut().insert(
             "x-auth-token",
-            HeaderValue::from_str(self.token.as_str()).map_err(|_| Error::RequestError)?,
+            HeaderValue::from_str(&self.token).map_err(|_| Error::RequestError)?,
         );
 
         // Add body into the new request if it's provided.

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -14,11 +14,11 @@ pub fn get_nodegroup(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
     );
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::NodegroupRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.nodegroup)
 }
@@ -31,11 +31,11 @@ pub fn list_nodegroups(
         "/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS
     );
-    let req = client.new_request(Method::GET, path.as_str(), None)?;
+    let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
 
     let deserialized: schemas::ListRoot =
-        serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeError(err, body))?;
+        serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.nodegroups)
 }
@@ -52,7 +52,7 @@ pub fn create_nodegroup(
         "/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS
     );
-    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    let req = client.new_request(Method::POST, &path, Some(serialized))?;
     client.do_request(req)?;
 
     Ok(())
@@ -67,7 +67,7 @@ pub fn delete_nodegroup(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
     );
-    let req = client.new_request(Method::DELETE, path.as_str(), None)?;
+    let req = client.new_request(Method::DELETE, &path, None)?;
     client.do_request(req)?;
 
     Ok(())
@@ -86,7 +86,7 @@ pub fn resize_nodegroup(
         "/{}/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id, RESIZE
     );
-    let req = client.new_request(Method::POST, path.as_str(), Some(serialized))?;
+    let req = client.new_request(Method::POST, &path, Some(serialized))?;
     client.do_request(req)?;
 
     Ok(())
@@ -105,7 +105,7 @@ pub fn update_nodegroup(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
     );
-    let req = client.new_request(Method::PUT, path.as_str(), Some(serialized))?;
+    let req = client.new_request(Method::PUT, &path, Some(serialized))?;
     client.do_request(req)?;
 
     Ok(())

--- a/src/nodegroup/schemas.rs
+++ b/src/nodegroup/schemas.rs
@@ -70,7 +70,7 @@ pub struct CreateOpts {
 }
 
 impl CreateOpts {
-    pub fn new(count: u32, local_volume: bool, availability_zone: String) -> CreateOpts {
+    pub fn new(count: u32, local_volume: bool, availability_zone: &str) -> CreateOpts {
         CreateOpts {
             count,
             flavor_id: None,
@@ -81,15 +81,15 @@ impl CreateOpts {
             local_volume,
             keypair_name: None,
             affinity_policy: None,
-            availability_zone,
+            availability_zone: String::from(availability_zone),
             labels: None,
         }
     }
 
     /// Add a reference to a pre-created flavor.
     /// It can be omitted in most cases.
-    pub fn with_flavor_id(mut self, flavor_id: String) -> CreateOpts {
-        self.flavor_id = Some(flavor_id);
+    pub fn with_flavor_id(mut self, flavor_id: &str) -> CreateOpts {
+        self.flavor_id = Some(String::from(flavor_id));
         self
     }
 
@@ -116,20 +116,20 @@ impl CreateOpts {
 
     /// Add a blockstorage volume type for each node.
     /// It can be omitted only in cases when flavor_id is set and volume is local.
-    pub fn with_volume_type(mut self, volume_type: String) -> CreateOpts {
-        self.volume_type = Some(volume_type);
+    pub fn with_volume_type(mut self, volume_type: &str) -> CreateOpts {
+        self.volume_type = Some(String::from(volume_type));
         self
     }
 
     /// Add a name of the SSH key that will be added to all nodes.
-    pub fn with_keypair_name(mut self, keypair_name: String) -> CreateOpts {
-        self.keypair_name = Some(keypair_name);
+    pub fn with_keypair_name(mut self, keypair_name: &str) -> CreateOpts {
+        self.keypair_name = Some(String::from(keypair_name));
         self
     }
 
     /// Add an optional parameter to tune nodes affinity.
-    pub fn with_affinity_policy(mut self, affinity_policy: String) -> CreateOpts {
-        self.affinity_policy = Some(affinity_policy);
+    pub fn with_affinity_policy(mut self, affinity_policy: &str) -> CreateOpts {
+        self.affinity_policy = Some(String::from(affinity_policy));
         self
     }
 

--- a/tests/cluster.rs
+++ b/tests/cluster.rs
@@ -16,8 +16,8 @@ fn cluster_crud() {
     let client = common::setup();
 
     // Prepare create options.
-    let name = "cluster-crud".to_string();
-    let create_opts = cluster::schemas::CreateOpts::new(name, kube_version, region);
+    let name = "cluster-crud";
+    let create_opts = cluster::schemas::CreateOpts::new(name, &kube_version, &region);
 
     // Create a new cluster.
     let cluster = common::cluster_common::create_cluster_or_panic(&client, &create_opts);

--- a/tests/nodegroup.rs
+++ b/tests/nodegroup.rs
@@ -19,13 +19,13 @@ fn nodegroup_crud() {
     let client = common::setup();
 
     // Prepare create options.
-    let name = "nodegroup-crud".to_string();
+    let name = "nodegroup-crud";
     let nodegroup_opts = nodegroup::schemas::CreateOpts::new(1, false, az.clone())
         .with_cpus(1)
         .with_ram_mb(1024)
         .with_volume_gb(10)
         .with_volume_type(format!("fast.{}", az));
-    let create_opts = cluster::schemas::CreateOpts::new(name, kube_version, region)
+    let create_opts = cluster::schemas::CreateOpts::new(name, &kube_version, &region)
         .with_nodegroups(vec![nodegroup_opts]);
 
     // Create a new cluster.

--- a/tests/nodegroup.rs
+++ b/tests/nodegroup.rs
@@ -20,11 +20,11 @@ fn nodegroup_crud() {
 
     // Prepare create options.
     let name = "nodegroup-crud";
-    let nodegroup_opts = nodegroup::schemas::CreateOpts::new(1, false, az.clone())
+    let nodegroup_opts = nodegroup::schemas::CreateOpts::new(1, false, &az)
         .with_cpus(1)
         .with_ram_mb(1024)
         .with_volume_gb(10)
-        .with_volume_type(format!("fast.{}", az));
+        .with_volume_type(&format!("fast.{}", az));
     let create_opts = cluster::schemas::CreateOpts::new(name, &kube_version, &region)
         .with_nodegroups(vec![nodegroup_opts]);
 
@@ -32,11 +32,11 @@ fn nodegroup_crud() {
     let cluster = common::cluster_common::create_cluster_or_panic(&client, &create_opts);
 
     // Create a new nodegroup for the cluster.
-    let new_nodegroup_opts = nodegroup::schemas::CreateOpts::new(2, false, az.clone())
+    let new_nodegroup_opts = nodegroup::schemas::CreateOpts::new(2, false, &az)
         .with_cpus(1)
         .with_ram_mb(1024)
         .with_volume_gb(10)
-        .with_volume_type(format!("fast.{}", az));
+        .with_volume_type(&format!("fast.{}", az));
     common::nodegroup_common::create_nodegroup_or_panic(&client, &cluster.id, &new_nodegroup_opts);
 
     // List all cluster nodegroups.


### PR DESCRIPTION
Use &str instead of String in cluster module

Use references in cluster functions signatures to use less copies.

Use &str instead of String in nodegroup module

Use references in nodegroup functions signatures to use less copies.

Use Deref Coercion in lib.rs &str arguments

Use simple & instead of as_str in lib.rs.

Use Deref Coercion in kubeversion &str arguments

Use simple & instead of as_str in src/kubeversion/api.rs.

For #8 #7 