### PR TITLE
Implement reinstall_node method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,16 @@ impl Client {
     ) -> Result<node::schemas::Node, Error> {
         node::api::get_node(self, cluster_id, nodegroup_id, node_id)
     }
+
+    /// Reinstall a cluster node.
+    pub fn reinstall_node(
+        &self,
+        cluster_id: &str,
+        nodegroup_id: &str,
+        node_id: &str,
+    ) -> Result<(), Error> {
+        node::api::reinstall_node(self, cluster_id, nodegroup_id, node_id)
+    }
 }
 
 /// Methods to work with nodegroups.

--- a/src/node/api.rs
+++ b/src/node/api.rs
@@ -1,7 +1,7 @@
 use hyper::Method;
 
 use super::super::error::Error;
-use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS};
+use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS, REINSTALL};
 use super::super::Client;
 use super::schemas;
 
@@ -22,4 +22,20 @@ pub fn get_node(
         serde_json::from_str(&body).map_err(|err| Error::DeserializeError(err, body))?;
 
     Ok(deserialized.node)
+}
+
+pub fn reinstall_node(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+    node_id: &str,
+) -> Result<(), Error> {
+    let path = format!(
+        "/{}/{}/{}/{}/{}/{}/{}",
+        API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id, node_id, REINSTALL
+    );
+    let req = client.new_request(Method::POST, &path, None)?;
+    client.do_request(req)?;
+
+    Ok(())
 }

--- a/src/resource_url.rs
+++ b/src/resource_url.rs
@@ -10,3 +10,6 @@ pub const KUBEVERSIONS: &str = "kubeversions";
 /// Nodegroups resource URLs.
 pub const NODEGROUPS: &str = "nodegroups";
 pub const RESIZE: &str = "resize";
+
+/// Nodes resource URLs.
+pub const REINSTALL: &str = "reinstall";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod cluster_common;
+pub mod node_common;
 pub mod nodegroup_common;
 
 use selectel_mks::Client;

--- a/tests/common/node_common.rs
+++ b/tests/common/node_common.rs
@@ -1,0 +1,27 @@
+use super::cluster_common;
+use selectel_mks::Client;
+
+const NODE_REINSTALL_INTERVAL: u64 = 10_000;
+const NODE_REINSTALL_RETRIES: usize = 60;
+
+/// Function wraps nodegroup creation with retries.
+/// It panics in case of errors.
+pub fn reinstall_node_or_panic(
+    client: &Client,
+    cluster_id: &str,
+    nodegroup_id: &str,
+    node_id: &str,
+) {
+    client
+        .reinstall_node(cluster_id, nodegroup_id, node_id)
+        .unwrap_or_else(|error| panic!("unable to reinstall a node: {}", error));
+
+    cluster_common::wait_for_cluster_active_status_or_panic(
+        client,
+        cluster_id,
+        NODE_REINSTALL_INTERVAL,
+        NODE_REINSTALL_RETRIES,
+    );
+
+    println!("Reinstalled node {}", node_id);
+}

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -43,6 +43,14 @@ fn node_crud() {
         .expect("failed to get cluster node");
     println!("Node: {:?}\n", node);
 
+    // Reinstall the first node.
+    common::node_common::reinstall_node_or_panic(
+        &client,
+        &cluster.id,
+        &nodegroups[0].id,
+        &nodegroups[0].nodes[0].id,
+    );
+
     // Delete the created cluster.
     common::cluster_common::delete_cluster_or_panic(&client, &cluster.id);
 }


### PR DESCRIPTION
Add a method to reinstall a cluster node.

Extend node_crud integration test.

Add common testing reinstall_node_or_panic function.

For #9 