### PR TITLE
Use simple function names in API modules

### DIFF
--- a/src/cluster/api.rs
+++ b/src/cluster/api.rs
@@ -5,7 +5,7 @@ use super::super::resource_url::{API_VERSION, CLUSTERS};
 use super::super::Client;
 use super::schemas;
 
-pub fn get_cluster(client: &Client, cluster_id: &str) -> Result<schemas::Cluster, Error> {
+pub fn get(client: &Client, cluster_id: &str) -> Result<schemas::Cluster, Error> {
     let path = format!("/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id);
     let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
@@ -16,7 +16,7 @@ pub fn get_cluster(client: &Client, cluster_id: &str) -> Result<schemas::Cluster
     Ok(deserialized.cluster)
 }
 
-pub fn list_clusters(client: &Client) -> Result<Vec<schemas::Cluster>, Error> {
+pub fn list(client: &Client) -> Result<Vec<schemas::Cluster>, Error> {
     let path = format!("/{}/{}", API_VERSION, CLUSTERS);
     let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;
@@ -27,10 +27,7 @@ pub fn list_clusters(client: &Client) -> Result<Vec<schemas::Cluster>, Error> {
     Ok(deserialized.clusters)
 }
 
-pub fn create_cluster(
-    client: &Client,
-    opts: &schemas::CreateOpts,
-) -> Result<schemas::Cluster, Error> {
+pub fn create(client: &Client, opts: &schemas::CreateOpts) -> Result<schemas::Cluster, Error> {
     let root_opts = schemas::CreateOptsRoot { cluster: opts };
     let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
@@ -44,7 +41,7 @@ pub fn create_cluster(
     Ok(deserialized.cluster)
 }
 
-pub fn delete_cluster(client: &Client, cluster_id: &str) -> Result<(), Error> {
+pub fn delete(client: &Client, cluster_id: &str) -> Result<(), Error> {
     let path = format!("/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id);
     let req = client.new_request(Method::DELETE, &path, None)?;
     client.do_request(req)?;

--- a/src/kubeversion/api.rs
+++ b/src/kubeversion/api.rs
@@ -5,7 +5,7 @@ use super::super::resource_url::{API_VERSION, KUBEVERSIONS};
 use super::super::Client;
 use super::schemas;
 
-pub fn list_kube_versions(client: &Client) -> Result<Vec<schemas::KubeVersion>, Error> {
+pub fn list(client: &Client) -> Result<Vec<schemas::KubeVersion>, Error> {
     let path = format!("/{}/{}", API_VERSION, KUBEVERSIONS);
     let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,12 +172,12 @@ impl Client {
 impl Client {
     /// Get a cluster.
     pub fn get_cluster(&self, cluster_id: &str) -> Result<cluster::schemas::Cluster, Error> {
-        cluster::api::get_cluster(self, cluster_id)
+        cluster::api::get(self, cluster_id)
     }
 
     /// List clusters.
     pub fn list_clusters(&self) -> Result<Vec<cluster::schemas::Cluster>, Error> {
-        cluster::api::list_clusters(self)
+        cluster::api::list(self)
     }
 
     /// Create a cluster.
@@ -185,12 +185,12 @@ impl Client {
         &self,
         opts: &cluster::schemas::CreateOpts,
     ) -> Result<cluster::schemas::Cluster, Error> {
-        cluster::api::create_cluster(self, opts)
+        cluster::api::create(self, opts)
     }
 
     /// Delete a cluster.
     pub fn delete_cluster(&self, cluster_id: &str) -> Result<(), Error> {
-        cluster::api::delete_cluster(self, cluster_id)
+        cluster::api::delete(self, cluster_id)
     }
 }
 
@@ -198,7 +198,7 @@ impl Client {
 impl Client {
     /// List all Kubernetes versions.
     pub fn list_kube_versions(&self) -> Result<Vec<kubeversion::schemas::KubeVersion>, Error> {
-        kubeversion::api::list_kube_versions(self)
+        kubeversion::api::list(self)
     }
 }
 
@@ -211,7 +211,7 @@ impl Client {
         nodegroup_id: &str,
         node_id: &str,
     ) -> Result<node::schemas::Node, Error> {
-        node::api::get_node(self, cluster_id, nodegroup_id, node_id)
+        node::api::get(self, cluster_id, nodegroup_id, node_id)
     }
 
     /// Reinstall a cluster node.
@@ -221,7 +221,7 @@ impl Client {
         nodegroup_id: &str,
         node_id: &str,
     ) -> Result<(), Error> {
-        node::api::reinstall_node(self, cluster_id, nodegroup_id, node_id)
+        node::api::reinstall(self, cluster_id, nodegroup_id, node_id)
     }
 }
 
@@ -233,7 +233,7 @@ impl Client {
         cluster_id: &str,
         nodegroup_id: &str,
     ) -> Result<nodegroup::schemas::Nodegroup, Error> {
-        nodegroup::api::get_nodegroup(self, cluster_id, nodegroup_id)
+        nodegroup::api::get(self, cluster_id, nodegroup_id)
     }
 
     /// List cluster nodegroups.
@@ -241,7 +241,7 @@ impl Client {
         &self,
         cluster_id: &str,
     ) -> Result<Vec<nodegroup::schemas::Nodegroup>, Error> {
-        nodegroup::api::list_nodegroups(self, cluster_id)
+        nodegroup::api::list(self, cluster_id)
     }
 
     /// Create a cluster nodegroup.
@@ -250,12 +250,12 @@ impl Client {
         cluster_id: &str,
         opts: &nodegroup::schemas::CreateOpts,
     ) -> Result<(), Error> {
-        nodegroup::api::create_nodegroup(self, cluster_id, opts)
+        nodegroup::api::create(self, cluster_id, opts)
     }
 
     /// Delete a cluster nodegroup.
     pub fn delete_nodegroup(&self, cluster_id: &str, nodegroup_id: &str) -> Result<(), Error> {
-        nodegroup::api::delete_nodegroup(self, cluster_id, nodegroup_id)
+        nodegroup::api::delete(self, cluster_id, nodegroup_id)
     }
 
     /// Resize a cluster nodegroup.
@@ -265,7 +265,7 @@ impl Client {
         nodegroup_id: &str,
         opts: &nodegroup::schemas::ResizeOpts,
     ) -> Result<(), Error> {
-        nodegroup::api::resize_nodegroup(self, cluster_id, nodegroup_id, opts)
+        nodegroup::api::resize(self, cluster_id, nodegroup_id, opts)
     }
 
     /// Update a cluster nodegroup.
@@ -275,7 +275,7 @@ impl Client {
         nodegroup_id: &str,
         opts: &nodegroup::schemas::UpdateOpts,
     ) -> Result<(), Error> {
-        nodegroup::api::update_nodegroup(self, cluster_id, nodegroup_id, opts)
+        nodegroup::api::update(self, cluster_id, nodegroup_id, opts)
     }
 }
 
@@ -283,12 +283,12 @@ impl Client {
 impl Client {
     /// Get a task.
     pub fn get_task(&self, cluster_id: &str, task_id: &str) -> Result<task::schemas::Task, Error> {
-        task::api::get_task(self, cluster_id, task_id)
+        task::api::get(self, cluster_id, task_id)
     }
 
     /// List tasks.
     pub fn list_tasks(&self, cluster_id: &str) -> Result<Vec<task::schemas::Task>, Error> {
-        task::api::list_tasks(self, cluster_id)
+        task::api::list(self, cluster_id)
     }
 }
 

--- a/src/node/api.rs
+++ b/src/node/api.rs
@@ -5,7 +5,7 @@ use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS, REINSTALL};
 use super::super::Client;
 use super::schemas;
 
-pub fn get_node(
+pub fn get(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,
@@ -24,7 +24,7 @@ pub fn get_node(
     Ok(deserialized.node)
 }
 
-pub fn reinstall_node(
+pub fn reinstall(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,

--- a/src/nodegroup/api.rs
+++ b/src/nodegroup/api.rs
@@ -5,7 +5,7 @@ use super::super::resource_url::{API_VERSION, CLUSTERS, NODEGROUPS, RESIZE};
 use super::super::Client;
 use super::schemas;
 
-pub fn get_nodegroup(
+pub fn get(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,
@@ -23,10 +23,7 @@ pub fn get_nodegroup(
     Ok(deserialized.nodegroup)
 }
 
-pub fn list_nodegroups(
-    client: &Client,
-    cluster_id: &str,
-) -> Result<Vec<schemas::Nodegroup>, Error> {
+pub fn list(client: &Client, cluster_id: &str) -> Result<Vec<schemas::Nodegroup>, Error> {
     let path = format!(
         "/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS
@@ -40,11 +37,7 @@ pub fn list_nodegroups(
     Ok(deserialized.nodegroups)
 }
 
-pub fn create_nodegroup(
-    client: &Client,
-    cluster_id: &str,
-    opts: &schemas::CreateOpts,
-) -> Result<(), Error> {
+pub fn create(client: &Client, cluster_id: &str, opts: &schemas::CreateOpts) -> Result<(), Error> {
     let root_opts = schemas::CreateOptsRoot { nodegroup: opts };
     let serialized = serde_json::to_string(&root_opts).map_err(Error::SerializeError)?;
 
@@ -58,11 +51,7 @@ pub fn create_nodegroup(
     Ok(())
 }
 
-pub fn delete_nodegroup(
-    client: &Client,
-    cluster_id: &str,
-    nodegroup_id: &str,
-) -> Result<(), Error> {
+pub fn delete(client: &Client, cluster_id: &str, nodegroup_id: &str) -> Result<(), Error> {
     let path = format!(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, NODEGROUPS, nodegroup_id
@@ -73,7 +62,7 @@ pub fn delete_nodegroup(
     Ok(())
 }
 
-pub fn resize_nodegroup(
+pub fn resize(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,
@@ -92,7 +81,7 @@ pub fn resize_nodegroup(
     Ok(())
 }
 
-pub fn update_nodegroup(
+pub fn update(
     client: &Client,
     cluster_id: &str,
     nodegroup_id: &str,

--- a/src/task/api.rs
+++ b/src/task/api.rs
@@ -5,7 +5,7 @@ use super::super::resource_url::{API_VERSION, CLUSTERS, TASKS};
 use super::super::Client;
 use super::schemas;
 
-pub fn get_task(client: &Client, cluster_id: &str, task_id: &str) -> Result<schemas::Task, Error> {
+pub fn get(client: &Client, cluster_id: &str, task_id: &str) -> Result<schemas::Task, Error> {
     let path = format!(
         "/{}/{}/{}/{}/{}",
         API_VERSION, CLUSTERS, cluster_id, TASKS, task_id
@@ -19,7 +19,7 @@ pub fn get_task(client: &Client, cluster_id: &str, task_id: &str) -> Result<sche
     Ok(deserialized.task)
 }
 
-pub fn list_tasks(client: &Client, cluster_id: &str) -> Result<Vec<schemas::Task>, Error> {
+pub fn list(client: &Client, cluster_id: &str) -> Result<Vec<schemas::Task>, Error> {
     let path = format!("/{}/{}/{}/{}", API_VERSION, CLUSTERS, cluster_id, TASKS);
     let req = client.new_request(Method::GET, &path, None)?;
     let body = client.do_request(req)?;


### PR DESCRIPTION
Do not use module name in functions names for API modules.

For #39 