### PR TITLE
Extend README.md, add builder example, extend cluster inline doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 Pure Rust bindings to the Selectel MKS V1 API.
 
+## Getting Started
+
+Add `selectel-mks-rust` to the `Cargo.toml`:
+
+```toml
+[dependencies]
+selectel-mks-rust = "0.2.0"
+```
+
+Prepare a new `Client` instance and use methods to work with the MKS API.
+
+You can check `./examples` directory and also `./test` directory to see how `Client` methods are used to work with the MKS API.
+
 ## TLS
 
 `selectel-mks-rust` supports [rustls] and [rust-native-tls] for TLS connectivity.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 Pure Rust bindings to the Selectel MKS V1 API.
 
+## TLS
+
+`selectel-mks-rust` supports [rustls] and [rust-native-tls] for TLS connectivity.
+`rustls` is used by default, but one can toggle support with Cargo features:
+
+```toml
+[dependencies.selectel-mks-rust]
+version = "0.2.0"
+default-features = false
+features = ["rust-native-tls"]
+```
+
+[rustls]: https://github.com/ctz/rustls
+[rust-native-tls]: https://github.com/sfackler/rust-native-tls
+
 ## License
 
 Licensed under either of

--- a/examples/client_with_builder.rs
+++ b/examples/client_with_builder.rs
@@ -1,0 +1,23 @@
+use selectel_mks::Client;
+use std::time::Duration;
+
+fn main() {
+    // Configure custom timeout for a new client.
+    let timeout_secs = 10;
+
+    // Get endpoint for the needed region:
+    //  - ru-1: https://ru-1.mks.selcloud.ru
+    //  - ru-2: https://ru-2.mks.selcloud.ru
+    //  - ru-3: https://ru-3.mks.selcloud.ru
+    //  - ru-7: https://ru-7.mks.selcloud.ru
+    //  - ru-8: https://ru-8.mks.selcloud.ru
+    let endpoint = "https://ru-1.mks.selcloud.ru";
+
+    // Get project-scoped token value.
+    let token = "token_value";
+
+    let _client = Client::builder()
+        .with_timeout(Duration::from_secs(timeout_secs))
+        .build(endpoint, token)
+        .expect("failed to initialize MKS client");
+}

--- a/src/cluster/schemas.rs
+++ b/src/cluster/schemas.rs
@@ -202,12 +202,16 @@ impl CreateOpts {
     }
 
     /// Add enable_autorepair flag.
+    /// This flag indicates if worker nodes are allowed to be reinstalled automatically
+    /// in case of their unavailability or unhealthiness.
     pub fn with_enable_autorepair(mut self, enable_autorepair: bool) -> CreateOpts {
         self.enable_autorepair = Some(enable_autorepair);
         self
     }
 
     /// Add enable_patch_version_auto_upgrade flag.
+    /// This flag indicates if Kubernetes patch version of the cluster is allowed to be upgraded
+    /// automatically.
     pub fn with_enable_patch_version_auto_upgrade(
         mut self,
         enable_patch_version_auto_upgrade: bool,
@@ -217,12 +221,16 @@ impl CreateOpts {
     }
 
     /// Add zonal flag.
+    /// This flag indicates that cluster has only a single master and that
+    /// control-plane is not in highly available mode.
     pub fn with_zonal(mut self, zonal: bool) -> CreateOpts {
         self.zonal = Some(zonal);
         self
     }
 
     /// Add kubernetes_options.
+    /// This parameter represents additional options such as Pod Security Policy,
+    /// feature gates, etc.
     pub fn with_kubernetes_options(mut self, kubernetes_options: KubernetesOptions) -> CreateOpts {
         self.kubernetes_options = Some(kubernetes_options);
         self


### PR DESCRIPTION
Extend inline cluster documentation

Add TLS section into README.md.

Add getting started section into README.md.

Add example to init new client with builder.

For #19 