### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["api", "sdk", "selectel", "mks", "kubernetes"]
 license = "MIT OR Apache-2.0"
 name = "selectel-mks"
 repository = "https://github.com/ozerovandrei/selectel-mks-rust.git"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
This version contains some breaking API changes from 0.1.0.

New Client methods to work with clusters:
  - get_cluster
  - list_clusters
  - create_cluster
  - delete_cluster

New Client methods to work with nodegroups:
  - get_nodegroup
  - list_nodegroups
  - create_nodegroup
  - update_nodegroup
  - resize_nodegroup
  - delete_nodegroup

New Client methods to work with nodes:
  - get_node
  - reinstall_node

New Client methods to work with tasks:
  - get_task
  - list_tasks

New modules with public structs and enums: cluster, nodegroup, node,
task.