### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["api", "sdk", "selectel", "mks", "kubernetes"]
 license = "MIT OR Apache-2.0"
 name = "selectel-mks"
 repository = "https://github.com/ozerovandrei/selectel-mks-rust.git"
-version = "0.2.1"
+version = "0.2.2"
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
This version adds serde::Serialize derive into all responses.

It also changes error::Error messages to start with uppercase.